### PR TITLE
makefile: use pkg-config to get correct XTT include flags

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -39,9 +39,16 @@ else ifeq ($(UNAME_SYS), Linux)
 endif
 
 CFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
-CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+CFLAGS += $(shell pkg-config --cflags xtt)
 
-LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei -lecdaa -Wl,-rpath,$(XAPTUM_TPM_ERLANG_LIBDIR) -L $(XAPTUM_TPM_ERLANG_LIBDIR) -lxaptum_tpm_erlang -lxtt
+CXXFLAGS += -fPIC -I $(ERTS_INCLUDE_DIR) -I $(ERL_INTERFACE_INCLUDE_DIR)
+CXXFLAGS += $(shell pkg-config --cflags xtt)
+
+LDLIBS += -L $(ERL_INTERFACE_LIB_DIR) -lerl_interface -lei
+LDLIBS += -Wl,-rpath,$(XAPTUM_TPM_ERLANG_LIBDIR) -L $(XAPTUM_TPM_ERLANG_LIBDIR) -lxaptum_tpm_erlang
+LDLIBS += $(shell pkg-config --libs xtt)
+LDLIBS += -lecdaa
+
 LDFLAGS += -shared
 
 # Verbosity.


### PR DESCRIPTION
The CFLAGS required by XTT depend on whether TPM support was enabled.
The pkg-config file installed by XTT contains the correct CFLAGS. This
commit changes the Makefile to query pkg-config for these flags.

The commit also splits the CFLAGS (and LDLIBS) assignments onto
multiple lines to improve readability.

@iguberman Please confirm that change builds on your machine.